### PR TITLE
Add simple Spring Boot backend

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,18 @@
+# Prompt History
+
+The following prompt was used to generate this project:
+
+```
+Prerequisites
+본인의 github 저장소(public)를 하나 준비해주세요.
+Spring boot framework 기반 환경에서 서버를 구현하세요.
+언어는 Java, Kotlin 사용이 가능합니다.
+본인이 구현한 서버를 면접관이 로컬 환경에서 실행해 볼 수 있도록 README.md 를 작성하세요.
+면접관은 추후에 제출하신 본인의 github 저장소를 clone 받아서 서버를 실행해 볼 예정입니다.
+저장소(DB, Redis 등)는 자유롭게 사용 가능 가능합니다.
+단, 면접관이 local 환경에서 해당 저장소를 실행해 볼 수 있도록 README.md 파일에 가이드를 작성해 주세요.
+예) 서버 실행 전, 터미널에서 아래와 같이 실행하시오.
+$> docker pull redis:latest && docker run -d -p 6379:6379 redis:latest
+과제 수행 간, AI assistence 를 최대한 적극적으로 활용해주세요.
+단, PROMPT.md 파일을 별도로 생성하셔서, 활용하신 모든 프롬프트들을 기록해 주세요.
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # hyundai-autoever-backend-task
-Security Service Development Backend 
+
+This project is a simple Spring Boot application used for the Hyundai AutoEver backend task. It exposes a single REST endpoint to verify the server is running.
+
+## Requirements
+
+- Java 17 or later
+- Maven 3.8+
+
+## Running the application
+
+Clone the repository and build the project using Maven:
+
+```bash
+mvn clean package
+```
+
+Run the generated JAR file:
+
+```bash
+java -jar target/security-service-0.0.1-SNAPSHOT.jar
+```
+
+The application will start on port `8080`. You can verify it by opening your browser or executing:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+You should see the response `Hello, world`.
+
+## Docker and other services
+
+This project does not require external services like Redis or a database. If you wish to run Redis for future development you can use:
+
+```bash
+docker pull redis:latest && docker run -d -p 6379:6379 redis:latest
+```
+
+## Prompt history
+All prompts used with AI assistance for this task are recorded in [PROMPT.md](PROMPT.md).

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>security-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/security/Application.java
+++ b/src/main/java/com/example/security/Application.java
@@ -1,0 +1,11 @@
+package com.example.security;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/src/main/java/com/example/security/controller/HelloController.java
+++ b/src/main/java/com/example/security/controller/HelloController.java
@@ -1,0 +1,12 @@
+package com.example.security.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, world";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=8080

--- a/src/test/java/com/example/security/ApplicationTests.java
+++ b/src/test/java/com/example/security/ApplicationTests.java
@@ -1,0 +1,11 @@
+package com.example.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add simple Spring Boot application with a `/hello` endpoint
- document build and run steps
- store user prompt in `PROMPT.md`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a39748c60832a81889c366ff0983d