### PR TITLE
Implement user registration and admin management APIs

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,4 @@
+# Prompts Used
+- Implemented signup, login, and admin APIs.
+- Configured in-memory H2 database and security settings.
+- Created README with instructions.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Backend Task
+
+This project is a simple Spring Boot application that provides user registration and management APIs.
+
+## Requirements
+- Java 17+
+- Gradle 8+
+
+## Running the Application
+The application uses an in-memory H2 database so no additional setup is required.
+
+```bash
+# run tests (optional)
+gradle test
+
+# run the server
+gradle bootRun
+```
+
+Access the H2 console at `http://localhost:8080/h2-console` with JDBC URL `jdbc:h2:mem:testdb`.
+
+## Admin Credentials
+Basic authentication is required for admin APIs.
+- **username:** `admin`
+- **password:** `1212`
+
+## Example Usage
+```bash
+# signup
+curl -X POST http://localhost:8080/api/users/signup \
+  -H 'Content-Type: application/json' \
+  -d '{"account":"user1","password":"pass","name":"User","regNo":"1234567890123","phone":"01012345678","address":"서울특별시 강남구"}'
+
+# login
+TOKEN=$(curl -s -X POST http://localhost:8080/api/users/login -H 'Content-Type: application/json' -d '{"account":"user1","password":"pass"}')
+
+# my page
+curl http://localhost:8080/api/users/me -H "X-Auth-Token: $TOKEN"
+```
+
+Admin example:
+```bash
+# list users
+curl -u admin:1212 http://localhost:8080/api/admin/users
+```

--- a/src/main/java/com/autoever/backend/SecurityConfig.java
+++ b/src/main/java/com/autoever/backend/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.autoever.backend;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable());
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/admin/**").authenticated()
+                .anyRequest().permitAll()
+        );
+        http.httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager inMemoryUserDetailsManager(PasswordEncoder encoder) {
+        return new InMemoryUserDetailsManager(
+                User.withUsername("admin")
+                        .password(encoder.encode("1212"))
+                        .roles("ADMIN")
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/autoever/backend/user/User.java
+++ b/src/main/java/com/autoever/backend/user/User.java
@@ -1,0 +1,38 @@
+package com.autoever.backend.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "account"),
+        @UniqueConstraint(columnNames = "regNo")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String account;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String regNo;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private String address;
+}

--- a/src/main/java/com/autoever/backend/user/UserRepository.java
+++ b/src/main/java/com/autoever/backend/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.autoever.backend.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByAccount(String account);
+    boolean existsByRegNo(String regNo);
+    Optional<User> findByAccount(String account);
+}

--- a/src/main/java/com/autoever/backend/user/UserService.java
+++ b/src/main/java/com/autoever/backend/user/UserService.java
@@ -1,0 +1,66 @@
+package com.autoever.backend.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // simple in-memory token store
+    private final Map<String, Long> tokenStore = new ConcurrentHashMap<>();
+
+    public User signup(User user) {
+        if (userRepository.existsByAccount(user.getAccount())) {
+            throw new IllegalArgumentException("account exists");
+        }
+        if (userRepository.existsByRegNo(user.getRegNo())) {
+            throw new IllegalArgumentException("regNo exists");
+        }
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
+    }
+
+    public String login(String account, String password) {
+        User user = userRepository.findByAccount(account)
+                .orElseThrow(() -> new IllegalArgumentException("invalid credentials"));
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("invalid credentials");
+        }
+        String token = UUID.randomUUID().toString();
+        tokenStore.put(token, user.getId());
+        return token;
+    }
+
+    public Optional<User> findByToken(String token) {
+        Long id = tokenStore.get(token);
+        if (id == null) return Optional.empty();
+        return userRepository.findById(id);
+    }
+
+    public User updateUser(Long id, String password, String address) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("user not found"));
+        if (password != null) {
+            user.setPassword(passwordEncoder.encode(password));
+        }
+        if (address != null) {
+            user.setAddress(address);
+        }
+        return userRepository.save(user);
+    }
+
+    public void deleteUser(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    public List<User> findAll(int page, int size) {
+        return userRepository.findAll(org.springframework.data.domain.PageRequest.of(page, size)).getContent();
+    }
+}

--- a/src/main/java/com/autoever/backend/user/controller/AdminController.java
+++ b/src/main/java/com/autoever/backend/user/controller/AdminController.java
@@ -1,0 +1,40 @@
+package com.autoever.backend.user.controller;
+
+import com.autoever.backend.user.User;
+import com.autoever.backend.user.UserService;
+import com.autoever.backend.user.dto.UpdateRequest;
+import com.autoever.backend.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/users")
+public class AdminController {
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<List<UserDto>> list(@RequestParam(defaultValue = "0") int page,
+                                              @RequestParam(defaultValue = "10") int size) {
+        List<UserDto> users = userService.findAll(page, size).stream()
+                .map(UserDto::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(users);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserDto> update(@PathVariable Long id, @RequestBody UpdateRequest request) {
+        User user = userService.updateUser(id, request.getPassword(), request.getAddress());
+        return ResponseEntity.ok(UserDto.from(user));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/autoever/backend/user/controller/AuthController.java
+++ b/src/main/java/com/autoever/backend/user/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.autoever.backend.user.controller;
+
+import com.autoever.backend.user.User;
+import com.autoever.backend.user.UserService;
+import com.autoever.backend.user.dto.LoginRequest;
+import com.autoever.backend.user.dto.SignupRequest;
+import com.autoever.backend.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class AuthController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<UserDto> signup(@RequestBody SignupRequest request) {
+        User user = User.builder()
+                .account(request.getAccount())
+                .password(request.getPassword())
+                .name(request.getName())
+                .regNo(request.getRegNo())
+                .phone(request.getPhone())
+                .address(request.getAddress())
+                .build();
+        return ResponseEntity.ok(UserDto.from(userService.signup(user)));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody LoginRequest request) {
+        String token = userService.login(request.getAccount(), request.getPassword());
+        return ResponseEntity.ok(token);
+    }
+}

--- a/src/main/java/com/autoever/backend/user/controller/UserController.java
+++ b/src/main/java/com/autoever/backend/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.autoever.backend.user.controller;
+
+import com.autoever.backend.user.User;
+import com.autoever.backend.user.UserService;
+import com.autoever.backend.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto> me(@RequestHeader("X-Auth-Token") String token) {
+        User user = userService.findByToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("invalid token"));
+        // return only big region in address
+        String region = user.getAddress().split(" ")[0];
+        User sanitized = User.builder()
+                .id(user.getId())
+                .account(user.getAccount())
+                .name(user.getName())
+                .regNo(user.getRegNo())
+                .phone(user.getPhone())
+                .address(region)
+                .build();
+        return ResponseEntity.ok(UserDto.from(sanitized));
+    }
+}

--- a/src/main/java/com/autoever/backend/user/dto/LoginRequest.java
+++ b/src/main/java/com/autoever/backend/user/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.autoever.backend.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+    private String account;
+    private String password;
+}

--- a/src/main/java/com/autoever/backend/user/dto/SignupRequest.java
+++ b/src/main/java/com/autoever/backend/user/dto/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.autoever.backend.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequest {
+    private String account;
+    private String password;
+    private String name;
+    private String regNo;
+    private String phone;
+    private String address;
+}

--- a/src/main/java/com/autoever/backend/user/dto/UpdateRequest.java
+++ b/src/main/java/com/autoever/backend/user/dto/UpdateRequest.java
@@ -1,0 +1,11 @@
+package com.autoever.backend.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateRequest {
+    private String password;
+    private String address;
+}

--- a/src/main/java/com/autoever/backend/user/dto/UserDto.java
+++ b/src/main/java/com/autoever/backend/user/dto/UserDto.java
@@ -1,0 +1,27 @@
+package com.autoever.backend.user.dto;
+
+import com.autoever.backend.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserDto {
+    private Long id;
+    private String account;
+    private String name;
+    private String regNo;
+    private String phone;
+    private String address;
+
+    public static UserDto from(User user) {
+        return new UserDto(
+                user.getId(),
+                user.getAccount(),
+                user.getName(),
+                user.getRegNo(),
+                user.getPhone(),
+                user.getAddress()
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=backend
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true


### PR DESCRIPTION
## Summary
- add simple user entity and CRUD service
- implement signup/login endpoints
- add admin endpoints protected by basic auth
- return region-only address for user detail
- configure H2 database and security
- document run instructions

## Testing
- `gradle test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3c9adeb4832aa4424be1c535b71b